### PR TITLE
Add physical interaction core classes

### DIFF
--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/InteractTracker.cs
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/InteractTracker.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using UdonSharp;
+using UnityEngine;
+using VRC.SDKBase;
+
+namespace Varneon.VUdon.PlayerTracker.Abstract
+{
+    /// <summary>
+    /// Abstract tracker for physical interactions
+    /// </summary>
+    [DefaultExecutionOrder(-2146483648)]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+    public abstract class InteractTracker : UdonSharpBehaviour
+    {
+        /// <summary>
+        /// Type of this tracker
+        /// </summary>
+        public TrackerType TrackerType;
+
+        [SuppressMessage("Performance", "UNT0026:GetComponent always allocates", Justification = "<Pending>")]
+        public void OnTriggerEnter(Collider other)
+        {
+            if (!Utilities.IsValid(other) || other == null) { return; }
+
+            TouchReceiver receiver = other.GetComponent<TouchReceiver>();
+
+            if (receiver == null) { return; }
+
+            OnInteractTrackerEntered(receiver);
+        }
+
+        [SuppressMessage("Performance", "UNT0026:GetComponent always allocates", Justification = "<Pending>")]
+        public void OnTriggerExit(Collider other)
+        {
+            if (!Utilities.IsValid(other) || other == null) { return; }
+
+            TouchReceiver receiver = other.GetComponent<TouchReceiver>();
+
+            if (receiver == null) { return; }
+
+            OnInteractTrackerExited(receiver);
+        }
+
+        protected virtual void OnInteractTrackerEntered(TouchReceiver receiver)
+        {
+            receiver._OnInteractTrackerEntered(TrackerType, transform);
+        }
+
+        protected virtual void OnInteractTrackerExited(TouchReceiver receiver)
+        {
+            receiver._OnInteractTrackerExited(TrackerType);
+        }
+    }
+}

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/InteractTracker.cs.meta
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/InteractTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bc3621c567aeba4881c15e746f26bb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/TouchReceiver.cs
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/TouchReceiver.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using UdonSharp;
+using UnityEngine;
+
+namespace Varneon.VUdon.PlayerTracker.Abstract
+{
+    /// <summary>
+    /// Abstract receiver for physical interactions
+    /// </summary>
+    public abstract class TouchReceiver : UdonSharpBehaviour
+    {
+        [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
+        public abstract void _OnInteractTrackerEntered(TrackerType type, Transform tracker);
+
+        [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
+        public abstract void _OnInteractTrackerExited(TrackerType type);
+    }
+}

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/TouchReceiver.cs.meta
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/Abstract/TouchReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95f1cb7b583dda84e8a072a39d95fa52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.asset
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.asset
@@ -1,0 +1,113 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: InteractTracker
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: ecdb48287f263ca44ad51d6d14f5a591,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: 425b7b38eae9b524793dd1eb314b6d6f, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 1
+  hasInteractEvent: 0
+  scriptID: -2367310274219365563
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: TrackerType
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: TrackerType
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Varneon.VUdon.PlayerTracker.TrackerType, Varneon.VUdon.PlayerTracker.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 4|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Int32, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 5|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.asset.meta
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dcd15a2e188515e4eb870ed4ef367d46
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.cs
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.cs
@@ -1,0 +1,17 @@
+﻿using Varneon.VUdon.PlayerTracker.Abstract;
+
+namespace Varneon.VUdon.PlayerTracker
+{
+    public class InteractTracker : Abstract.InteractTracker
+    {
+        protected override void OnInteractTrackerEntered(TouchReceiver receiver)
+        {
+            base.OnInteractTrackerEntered(receiver);
+        }
+
+        protected override void OnInteractTrackerExited(TouchReceiver receiver)
+        {
+            base.OnInteractTrackerExited(receiver);
+        }
+    }
+}

--- a/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.cs.meta
+++ b/Packages/com.varneon.vudon.player-tracker/Runtime/Udon Programs/InteractTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 425b7b38eae9b524793dd1eb314b6d6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`InteractTracker` is a component for attaching to your tracked points and are used to detect entries to any trigger colliders that support touch
`TouchReceiver` is an abstract class for receiving touch events from `InteractTracker`